### PR TITLE
Add turbo9sim smoke image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,24 @@
 .DS_Store
+
+# Build outputs
+ports/turbo9sim/go
+ports/turbo9sim/go_fork
+ports/turbo9sim/go_smoke
+ports/turbo9sim/init
+ports/turbo9sim/ioman_full
+ports/turbo9sim/ioman_uio
+ports/turbo9sim/kernel_full
+ports/turbo9sim/kernel_min
+ports/turbo9sim/kernel_uio
+ports/turbo9sim/mdir
+ports/turbo9sim/mfree
+ports/turbo9sim/procs
+ports/turbo9sim/scf
+ports/turbo9sim/scvt
+ports/turbo9sim/shell
+ports/turbo9sim/term
+ports/turbo9sim/tkt9sim_full
+ports/turbo9sim/tkt9sim_min
+ports/turbo9sim/tkt9sim_uio
+ports/turbo9sim/*.img
+ports/turbo9sim/*.img.rom

--- a/ports/turbo9sim/Makefile
+++ b/ports/turbo9sim/Makefile
@@ -42,6 +42,7 @@ KERNELS  = kernel_full kernel_uio kernel_min
 OBJS_FULL = kernel_full init tkt9sim_full ioman_full scf scvt term go_fork shell mfree mdir procs
 OBJS_UIO = kernel_uio init tkt9sim_uio ioman_uio scf scvt term $(COMMANDS)
 OBJS_MIN = kernel_min init tkt9sim_min $(COMMANDS)
+OBJS_SMOKE = kernel_min init tkt9sim_min go_smoke
 
 all:	turbos_full.img turbos_uio.img turbos_min.img
 	ls -l turbos_full.img.rom turbos_uio.img.rom turbos_min.img.rom
@@ -77,6 +78,9 @@ tkt9sim_uio: tkt9sim.asm
 	$(AS) $(KERNEL_UIO) $? -o$@
 	
 tkt9sim_min: tkt9sim.asm
+	$(AS) $(KERNEL_MIN) $? -o$@
+
+go_smoke: go_smoke.asm
 	$(AS) $(KERNEL_MIN) $? -o$@
 	
 lint: *.asm $(KERNEL_SOURCES) $(MODULE_SOURCES)
@@ -114,10 +118,19 @@ turbos_min.img: $(OBJS_MIN)
 	echo "obase=16; $(PADSIZE)-`wc -c <$@.rom`+20" | bc | xxd -r -p >> vectors.tmp
 	cat $@.tmp lastpage.tmp vectors.tmp > $@
 	rm *.tmp
+
+turbos_smoke.img: $(OBJS_SMOKE)
+	cat $? > $@.rom
+	cat $@.rom > $@.tmp
+	os9 padrom -b -c=0 $(PADSIZE) $@.tmp
+	dd if=/dev/zero of=lastpage.tmp bs=1 count=240
+	printf "\x00\x00\x01\x00\x01\x03\x01\x0F\x01\x0C\x01\x06\x01\x09" > vectors.tmp
+	echo "obase=16; $(PADSIZE)-`wc -c <$@.rom`+20" | bc | xxd -r -p >> vectors.tmp
+	cat $@.tmp lastpage.tmp vectors.tmp > $@
+	rm *.tmp
 	
 clean:
-	-$(RM) $(OBJS_FULL) $(OBJS_UIO) $(OBJS_MIN) *.rom *.img *.tmp *.list *.map lastpage
+	-$(RM) $(OBJS_FULL) $(OBJS_UIO) $(OBJS_MIN) $(OBJS_SMOKE) *.rom *.img *.tmp *.list *.map lastpage
 
 gh:
 	open "http://www.github.com/boisy/turbos"
-

--- a/ports/turbo9sim/go_smoke.asm
+++ b/ports/turbo9sim/go_smoke.asm
@@ -1,0 +1,39 @@
+*******************************************************************************
+* TurbOS
+*******************************************************************************
+* Hyper9 command-line smoke test program.
+
+ nam go
+ ttl Hyper9 smoke test program
+
+ use defs.d
+
+tylg set Prgrm+Objct
+atrv set ReEnt+rev
+rev set $01
+edition set 1
+
+ mod eom,name,tylg,atrv,start,size
+
+ org 0
+stack rmb 200
+size equ .
+
+name fcs /go/
+ fcb edition
+
+start leax message,pcr
+write@ lda ,x+
+ beq sleep@
+ sta MappedIOStart+Term.Out
+ bra write@
+sleep@ ldx #0
+ os9 F$Sleep
+ bra sleep@
+
+message fcc "TurbOS OK"
+ fcb C$CR,$0A,0
+
+ emod
+eom equ *
+ end


### PR DESCRIPTION
## Overview

Adds a dedicated `turbo9sim` smoke-test image for automated simulator checks. The new `go_smoke` program keeps the initial module name as `go`, so the existing `init` module can launch it, but emits a deterministic `TurbOS OK` string through the Hyper9 terminal output port.

## Notable Changes

- Adds `ports/turbo9sim/go_smoke.asm`.
- Adds a `turbos_smoke.img` build target.
- Ignores generated `turbo9sim` modules and image outputs.

## Verification

```sh
make -C turbos/ports/turbo9sim TURBOSDIR=/Volumes/Lagniappe/turbo-shelf/turbos turbos_smoke.img
make turbos-smoke
make turbos-full-smoke
```

Verified via turbo-shelf: `turbos_smoke.img` prints `TurbOS OK`, and the full image still boots to the shell and responds to `mdir`.
