### PR TITLE
Use full prerequisite list for turbo9sim images

### DIFF
--- a/ports/turbo9sim/Makefile
+++ b/ports/turbo9sim/Makefile
@@ -90,7 +90,7 @@ lint: *.asm $(KERNEL_SOURCES) $(MODULE_SOURCES)
 PADSIZE=65280
 
 turbos_full.img: $(OBJS_FULL)
-	cat $? > $@.rom
+	cat $^ > $@.rom
 	cat $@.rom > $@.tmp
 	os9 padrom -b -c=0 $(PADSIZE) $@.tmp
 	dd if=/dev/zero of=lastpage.tmp bs=1 count=240
@@ -100,7 +100,7 @@ turbos_full.img: $(OBJS_FULL)
 	rm *.tmp
 
 turbos_uio.img: $(OBJS_UIO)
-	cat $? > $@.rom
+	cat $^ > $@.rom
 	cat $@.rom > $@.tmp
 	os9 padrom -b -c=0 $(PADSIZE) $@.tmp
 	dd if=/dev/zero of=lastpage.tmp bs=1 count=240
@@ -110,7 +110,7 @@ turbos_uio.img: $(OBJS_UIO)
 	rm *.tmp
 
 turbos_min.img: $(OBJS_MIN)
-	cat $? > $@.rom
+	cat $^ > $@.rom
 	cat $@.rom > $@.tmp
 	os9 padrom -b -c=0 $(PADSIZE) $@.tmp
 	dd if=/dev/zero of=lastpage.tmp bs=1 count=240
@@ -120,7 +120,7 @@ turbos_min.img: $(OBJS_MIN)
 	rm *.tmp
 
 turbos_smoke.img: $(OBJS_SMOKE)
-	cat $? > $@.rom
+	cat $^ > $@.rom
 	cat $@.rom > $@.tmp
 	os9 padrom -b -c=0 $(PADSIZE) $@.tmp
 	dd if=/dev/zero of=lastpage.tmp bs=1 count=240


### PR DESCRIPTION
## Overview

Fixes the `turbo9sim` image rules to concatenate the full prerequisite list whenever an image target rebuilds. The previous `$?` form only included prerequisites newer than the target, which could produce partial ROM images during incremental rebuilds.

## Verification

```sh
rm -f ports/turbo9sim/turbos_smoke.img ports/turbo9sim/turbos_smoke.img.rom
make -C ports/turbo9sim TURBOSDIR=/Volumes/Lagniappe/turbo-shelf/turbos turbos_smoke.img
make turbos-smoke
make turbos-full-smoke
```

Verified the rebuilt smoke ROM concatenates `kernel_min init tkt9sim_min go_smoke` and the shelf smoke tests pass.
